### PR TITLE
Add events & Add testing scaffold, fixtures, and some unit tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,6 @@
+language: node_js
+node_js:
+  - "0.12"
+  - "0.11"
+  - "0.10"
+  - "iojs"

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -1,6 +1,8 @@
 module.exports = function( grunt ) {
   'use strict';
 
+  var merge = require( 'lodash.merge' );
+
   // Reusable JSHintRC options
   var jshintrc = grunt.file.readJSON( '.jshintrc' );
 
@@ -21,6 +23,9 @@ module.exports = function( grunt ) {
       },
       lib: {
         src: 'tasks/**/*.js'
+      },
+      tests: {
+        src: 'tests/**/*.js'
       }
     },
 
@@ -35,6 +40,17 @@ module.exports = function( grunt ) {
       lib: {
         options: jshintrc,
         src: 'tasks/**/*.js'
+      },
+      tests: {
+        options: merge( jshintrc, {
+          globals: {
+            describe: false,
+            it: false,
+            beforeEach: false,
+            afterEach: false
+          }
+        }),
+        src: 'tests/**/*.js'
       }
     }
 

--- a/package.json
+++ b/package.json
@@ -23,7 +23,9 @@
   ],
   "scripts": {
     "publish": "npm test",
-    "test": "grunt lint"
+    "lint": "grunt lint",
+    "pretest": "npm run lint",
+    "test": "mocha tests/unit"
   },
   "peerDependencies": {
     "grunt": ">=0.4.0"
@@ -33,13 +35,19 @@
     "tokenize-markdown": "^0.1.1"
   },
   "devDependencies": {
+    "bluebird": "^2.9.14",
+    "chai": "^2.1.2",
+    "chai-as-promised": "^4.3.1",
     "grunt": "^0.4.5",
     "grunt-cli": "^0.1.13",
     "grunt-contrib-jshint": "^0.11.0",
     "grunt-jscs": "^1.5.0",
     "jscs-stylish": "^0.3.1",
     "jshint-stylish": "^1.0.1",
-    "load-grunt-tasks": "^3.1.0"
+    "load-grunt-tasks": "^3.1.0",
+    "lodash.merge": "^3.0.3",
+    "mocha": "^2.2.1",
+    "sinon": "^1.14.1"
   },
   "files": [
     "tasks"

--- a/tasks/codeblock-jshint.js
+++ b/tasks/codeblock-jshint.js
@@ -63,7 +63,24 @@ module.exports = function( grunt ) {
     // Log results
     reporter( results );
 
-    // // Fail task if errors were logged unless force is set
-    done( ! results.length || force );
+    // If no errors occurred, we're green
+    var noErrors = ! results.length;
+
+    // Fail task if errors were logged, unless force is set
+    var passed = noErrors || force;
+
+    var eventType;
+
+    if ( noErrors ) {
+      eventType = 'success';
+    } else {
+      eventType = force ? 'forced' : 'error';
+    }
+
+    // Emit an event (used exclusively for testing)
+    grunt.event.emit( 'codeblock-jshint', eventType, results );
+
+    // End the task
+    done( passed );
   });
 };

--- a/tests/fixtures/failing.md
+++ b/tests/fixtures/failing.md
@@ -1,0 +1,25 @@
+# Failing Codeblocks
+
+```javascript
+// codeblock one: 2 errors
+var message = 'Where did my semicolon go'
+
+undefinedFunctionIsUndefined();
+```
+
+```js
+// Another codeblock: 1 error
+if ( 'we compare with null with not-threequals' == null ) {
+  console.log( 'this will fail' );
+}
+```
+
+```html
+<script>
+  var message = [
+    'since this is html, this will',
+    'not be evaluated and the missing',
+    'semi-colon will (still) not be caught'
+  ]
+</script>
+```

--- a/tests/fixtures/passing.md
+++ b/tests/fixtures/passing.md
@@ -1,0 +1,19 @@
+# Passing Codeblocks
+
+```javascript
+var message = 'This is a valid assignment';
+
+function doTheRightThing() {
+  return true;
+}
+```
+
+```html
+<script>
+  var message = [
+    'since this is html, this will',
+    'not be evaluated and the missing',
+    'semi-colon will not be caught'
+  ]
+</script>
+```

--- a/tests/unit/codeblock-jshint.js
+++ b/tests/unit/codeblock-jshint.js
@@ -1,0 +1,184 @@
+'use strict';
+
+var chai = require( 'chai' );
+chai.use( require( 'chai-as-promised' ) );
+var expect = chai.expect;
+var sinon = require( 'sinon' );
+
+/*jshint -W079 */// Suppress warning about redefiniton of `Promise`
+var Promise = require( 'bluebird' );
+var grunt = require( 'grunt' );
+
+/**
+ * Return a promise that resolves when the codeblock-jshint event is received
+ *
+ * @param  {Grunt} grunt Grunt
+ * @return {Promise}     A promise that will be resolved or rejected based on
+ *                       the results of the 'codeblock-jshint' Grunt event
+ */
+function makeTaskDonePromise( grunt ) {
+  return new Promise(function( resolve, reject ) {
+    grunt.event.once( 'codeblock-jshint', function( status, results ) {
+      // Ternary returns either resolve or reject, conditionally
+      ( status === 'error' ? reject : resolve )({
+        // Only "error" results in a rejection:
+        // "forced" and "success" both resolve the promise
+        status: status,
+        results: results
+      });
+    });
+  });
+}
+
+describe( 'codeblock-jshint.js', function() {
+  var codeblockJSHint;
+
+  beforeEach(function() {
+    // Get our task creation method
+    codeblockJSHint = require( '../../tasks/codeblock-jshint' );
+  });
+
+  it( 'registers a codeblock-jshint task', function() {
+    codeblockJSHint( grunt );
+    // Check that task is registered
+    expect( grunt.task.exists( 'codeblock-jshint' ) ).to.be.ok;
+  });
+
+  describe( 'codeblock-jshint task', function() {
+    var taskDone;
+
+    beforeEach(function() {
+      // Start the task queue as empty
+      grunt.task.clearQueue();
+
+      // Clear out previously-registered codeblock-jshint task
+      // console.log( require('lodash').keys( grunt.tasks ) );
+      // grunt.tasks._tasks.length = 0;
+
+      // Register task afresh
+      codeblockJSHint( grunt );
+
+      // Turn off all previously-registered event listeners
+      grunt.event.removeAllListeners( 'codeblock-jshint' );
+
+      // taskDone will notify us of when the task completes
+      taskDone = makeTaskDonePromise( grunt );
+
+      // Stub out grunt log methods
+      sinon.stub( grunt.log, 'error' );
+      sinon.stub( grunt.log, 'write' );
+      sinon.stub( grunt.log, 'writeln' );
+    });
+
+    afterEach(function() {
+      grunt.log.error.restore();
+      grunt.log.write.restore();
+      grunt.log.writeln.restore();
+    });
+
+    it( 'runs the task with the provided options', function() {
+
+      // Enqueue the 'codeblock-jshint' task
+      grunt.task.run( 'codeblock-jshint' );
+
+      // Set task options
+      grunt.initConfig({
+        'codeblock-jshint': {
+          src: [ 'tests/fixtures/passing.md' ]
+        }
+      });
+
+      // Run the task queue
+      grunt.task.start();
+
+      // Ensure promise eventually is resolved
+      var completion = taskDone.then(function( result ) {
+        expect( result ).to.have.property( 'status' );
+        expect( result.status ).to.equal( 'success' );
+
+        expect( result ).to.have.property( 'results' );
+        expect( result.results ).to.have.property( 'length' );
+        expect( result.results.length ).to.equal( 0 );
+
+        // Provide a message indicating test is over
+        return 'done';
+      });
+
+      // Ensure taskDone is resolved
+      return expect( completion ).to.eventually.become( 'done' );
+    });
+
+    it( 'fails when identifying syntax errors in JavaScript code blocks', function() {
+
+      // Enqueue the 'codeblock-jshint' task
+      grunt.task.run( 'codeblock-jshint' );
+
+      // Set task options
+      grunt.initConfig({
+        'codeblock-jshint': {
+          src: [ 'tests/fixtures/failing.md' ]
+        }
+      });
+
+      // Run the task queue
+      grunt.task.start();
+
+      // Verify that task fails
+      return expect( taskDone ).to.be.rejected;
+    });
+
+    it( 'passes even if errors are present when --force is specified', function() {
+
+      // Enqueue the 'codeblock-jshint' task
+      grunt.task.run( 'codeblock-jshint' );
+
+      // Set task options
+      grunt.initConfig({
+        'codeblock-jshint': {
+          options: {
+            force: true
+          },
+          src: [ 'tests/fixtures/failing.md' ]
+        }
+      });
+
+      // Run the task queue
+      grunt.task.start();
+
+      return expect( taskDone ).to.be.fulfilled;
+    });
+
+    it( 'correctly identifies syntax errors in JavaScript code blocks', function() {
+
+      // Enqueue the 'codeblock-jshint' task
+      grunt.task.run( 'codeblock-jshint' );
+
+      // Set task options
+      grunt.initConfig({
+        'codeblock-jshint': {
+          src: [ 'tests/fixtures/failing.md' ]
+        }
+      });
+
+      // Run the task queue
+      grunt.task.start();
+
+      var completion = taskDone.catch(function( result ) {
+        expect( result ).to.have.property( 'status' );
+        expect( result.status ).to.equal( 'error' );
+
+        expect( result ).to.have.property( 'results' );
+        expect( result.results ).to.have.property( 'length' );
+        expect( result.results.length ).to.equal( 2 );
+
+        // Provide a message indicating test is over
+        return 'failed';
+      });
+
+      // Ensure taskDone is resolved
+      return expect( completion ).to.eventually.become( 'failed' );
+    });
+
+  });
+
+});


### PR DESCRIPTION
Emitting events on success or failure allows us to programatically test the output of the plugin

These tests don't cover all functionality, but they verify the basics work
